### PR TITLE
Change mail user key to "mailUser".

### DIFF
--- a/lsf/options.py
+++ b/lsf/options.py
@@ -57,7 +57,7 @@ _OPTIONS = {o.name: o for o in
         Option('jobGroup', flag=api.SUB2_JOB_GROUP, flag_group='options2'),
         Option('inFile', flag=api.SUB_IN_FILE),
         Option('jobName', flag=api.SUB_JOB_NAME),
-        Option('mail_user', flag=api.SUB_MAIL_USER),
+        Option('mailUser', flag=api.SUB_MAIL_USER),
         Option('maxNumProcessors', cast_with=int),
         Option('numProcessors', cast_with=int),
         Option('outFile', flag=api.SUB_OUT_FILE),

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -18,7 +18,7 @@ class OptionTest(unittest.TestCase):
             'errFile': api.SUB_ERR_FILE,
             'inFile': api.SUB_IN_FILE,
             'jobName': api.SUB_JOB_NAME,
-            'mail_user': api.SUB_MAIL_USER,
+            'mailUser': api.SUB_MAIL_USER,
             'outFile': api.SUB_OUT_FILE,
             'projectName': api.SUB_PROJECT_NAME,
             'queue': api.SUB_QUEUE,


### PR DESCRIPTION
`mail_user` doesn't seem to exist, but `mailUser` does (as seen [here](https://www.bsc.es/support/LSF/9.1.2/api_ref/group__gpd__control__flag.html#g363a586839d14d6afc1384941d976e71)).
