### PR TITLE
Add a flag to not get back the execution info.

### DIFF
--- a/lsf/job.py
+++ b/lsf/job.py
@@ -29,13 +29,14 @@ __all__ = ['get_job']
 LOG = logging.getLogger(__name__)
 
 
-def get_job(job_id):
-    return Job(job_id)
+def get_job(job_id, include_exec_info=True):
+    return Job(job_id, include_exec_info)
 
 
 class Job(object):
-    def __init__(self, job_id):
+    def __init__(self, job_id, include_exec_info=True):
         self.job_id = job_id
+        self.include_exec_info = include_exec_info
 
     def __eq__(self, other):
         return self.job_id == other.job_id
@@ -50,7 +51,7 @@ class Job(object):
             'submit': _request_info(jobinfo.submit),
         }
 
-        result.update(_get_additional_lsf_supplied_fields(jobinfo))
+        result.update(_get_additional_lsf_supplied_fields(jobinfo, self.include_exec_info))
 
         return result
 
@@ -123,7 +124,7 @@ _EXEC_FIELDS = [
     'execUid',
     'execUsername',
 ]
-def _get_additional_lsf_supplied_fields(jobinfo):
+def _get_additional_lsf_supplied_fields(jobinfo, include_exec_info):
     result = {
         field: getattr(jobinfo, field) for field in _DIRECT_COPY_FIELDS
     }
@@ -140,7 +141,7 @@ def _get_additional_lsf_supplied_fields(jobinfo):
             if getattr(jobinfo, field) > 0
     })
 
-    if _exec_available(jobinfo):
+    if include_exec_info and _exec_available(jobinfo):
         result.update({
             field: getattr(jobinfo, field)
                 for field in _EXEC_FIELDS

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -29,6 +29,16 @@ class JobStatusTests(unittest.TestCase):
 
         self._verify_job_dict_additional_fields(job_dict)
 
+    def test_job_as_dict_without_exec(self):
+        job = lsf.get_job(self.job.job_id, include_exec_info=False)
+        job_dict = job.as_dict
+
+        self._verify_job_dict_statuses(job_dict['statuses'])
+        self._verify_job_dict_submit_portion(job_dict['submit'])
+
+        self._verify_job_dict_additional_fields(job_dict)
+        self.assertFalse('exHosts' in job_dict)
+
     def _verify_job_dict_statuses(self, statuses):
         self.assertGreater(len(statuses), 0)
         possible_valid_statuses = {'DONE', 'PDONE', 'PEND', 'RUN'}


### PR DESCRIPTION
This is a proposed approach to get around the fact that exHosts segfaults when a job is bsubbed with `-n 3`.  In our use of lsf-python, we don't really care what any of the execution info is... but someone else out there might?

(I would certainly welcome comments on ways this could be more pythonic!  I don't like that I repeated myself in the default value, for example.)
